### PR TITLE
Bug - src being copied to package.json

### DIFF
--- a/scripts/bluelibs-package-replace
+++ b/scripts/bluelibs-package-replace
@@ -3,7 +3,7 @@
 # Move this to /usr/local/bin/* as it can be very useful when you are testing this in other projects
 
 PACKAGE="$1"
-ROOT="/Users/yashsharma/Documents/CoC/bluelibs"
+ROOT="/Users/yashsharma/Documents/CoC/bluelibs/packages"
 
 rm -rf node_modules/\@bluelibs/$PACKAGE/dist
 rm -rf node_modules/\@bluelibs/$PACKAGE/src

--- a/scripts/bluelibs-package-replace
+++ b/scripts/bluelibs-package-replace
@@ -3,7 +3,7 @@
 # Move this to /usr/local/bin/* as it can be very useful when you are testing this in other projects
 
 PACKAGE="$1"
-ROOT="/Users/yashsharma/Documents/CoC/bluelibs/packages"
+ROOT="/Users/theodor/Projects/bluelibs/packages"
 
 rm -rf node_modules/\@bluelibs/$PACKAGE/dist
 rm -rf node_modules/\@bluelibs/$PACKAGE/src

--- a/scripts/bluelibs-package-replace
+++ b/scripts/bluelibs-package-replace
@@ -3,7 +3,7 @@
 # Move this to /usr/local/bin/* as it can be very useful when you are testing this in other projects
 
 PACKAGE="$1"
-ROOT="/Users/theodor/Projects/bluelibs/packages"
+ROOT="/Users/yashsharma/Documents/CoC/bluelibs"
 
 rm -rf node_modules/\@bluelibs/$PACKAGE/dist
 rm -rf node_modules/\@bluelibs/$PACKAGE/src
@@ -11,4 +11,4 @@ rm -rf node_modules/\@bluelibs/$PACKAGE/package.json
 
 cp -r $ROOT/$PACKAGE/dist "./node_modules/@bluelibs/$PACKAGE/dist"
 cp -r $ROOT/$PACKAGE/src "./node_modules/@bluelibs/$PACKAGE/src"
-cp -r $ROOT/$PACKAGE/src "./node_modules/@bluelibs/$PACKAGE/package.json"
+cp -r $ROOT/$PACKAGE/package.json "./node_modules/@bluelibs/$PACKAGE/package.json"


### PR DESCRIPTION
Fix - I have fixed a bug here where the src was being copied to the package.json.
Problem - When src is being copied to the package.json, the project stops considering the package as a node_module. 
