### PR TITLE
Added type to the parser in ICronConfig.schedule in package x-cron-bundle

### DIFF
--- a/packages/x-cron-bundle/src/__tests__/index.ts
+++ b/packages/x-cron-bundle/src/__tests__/index.ts
@@ -1,6 +1,7 @@
 import { ecosystem } from "./ecosystem";
 import { CronService } from "../services/CronService";
 import { ContainerInstance } from "@bluelibs/core";
+import { ParseStatic } from "later";
 
 test("crons do run", async () => {
   const eco = await ecosystem;

--- a/packages/x-cron-bundle/src/defs.ts
+++ b/packages/x-cron-bundle/src/defs.ts
@@ -1,10 +1,10 @@
-import { parse, ScheduleData } from "later";
+import { ParseStatic, ScheduleData } from "later";
 import { ContainerInstance } from "@bluelibs/core";
 import { ObjectID } from "@bluelibs/mongo-bundle";
 
 export interface ICronConfig {
   name: string;
-  schedule: (parser) => ScheduleData;
+  schedule: (parser: ParseStatic) => ScheduleData;
   job: (container: ContainerInstance) => void | Promise<void>;
   persist?: boolean;
   _timer?: any;

--- a/scripts/bluelibs-package-replace
+++ b/scripts/bluelibs-package-replace
@@ -3,7 +3,7 @@
 # Move this to /usr/local/bin/* as it can be very useful when you are testing this in other projects
 
 PACKAGE="$1"
-ROOT="/Users/theodor/Projects/bluelibs/packages"
+ROOT="/Users/yashsharma/Documents/CoC/bluelibs/packages"
 
 rm -rf node_modules/\@bluelibs/$PACKAGE/dist
 rm -rf node_modules/\@bluelibs/$PACKAGE/src
@@ -11,4 +11,4 @@ rm -rf node_modules/\@bluelibs/$PACKAGE/package.json
 
 cp -r $ROOT/$PACKAGE/dist "./node_modules/@bluelibs/$PACKAGE/dist"
 cp -r $ROOT/$PACKAGE/src "./node_modules/@bluelibs/$PACKAGE/src"
-cp -r $ROOT/$PACKAGE/src "./node_modules/@bluelibs/$PACKAGE/package.json"
+cp -r $ROOT/$PACKAGE/package.json "./node_modules/@bluelibs/$PACKAGE/package.json"

--- a/scripts/bluelibs-package-replace
+++ b/scripts/bluelibs-package-replace
@@ -3,7 +3,7 @@
 # Move this to /usr/local/bin/* as it can be very useful when you are testing this in other projects
 
 PACKAGE="$1"
-ROOT="/Users/yashsharma/Documents/CoC/bluelibs/packages"
+ROOT="/Users/theodor/Projects/bluelibs/packages"
 
 rm -rf node_modules/\@bluelibs/$PACKAGE/dist
 rm -rf node_modules/\@bluelibs/$PACKAGE/src


### PR DESCRIPTION
Changes :- 

Fix - I have added a type ParseStatic coming from library "later" (npm i --save-dev @types/later) to the param of function schedule in ICronConfig. 

Problem - It is a little puzzling for a new dev to get the structure of the parser and there is no direct linking of the parser to the package later. This will help the dev to know that parser comes from later and they can know more about it.