### PR TITLE
(fix) blameable behaviour should add/replace the fields only if userId exists in context

### DIFF
--- a/packages/mongo-bundle/src/__tests__/behaviors/behaviors.test.ts
+++ b/packages/mongo-bundle/src/__tests__/behaviors/behaviors.test.ts
@@ -15,12 +15,35 @@ describe("Behaviors", () => {
 
     const userIdToUpdate = "123";
     const userIdToCreate = "XXX";
+    const userIdToCreate2 = "YYY";
 
     const behaviors = container.get(Behaviors);
+
+    const getQueryBody = (insertedId: any) => ({
+      $: {
+        filters: {
+          _id: insertedId,
+        },
+      },
+      createdAt: 1,
+      updatedAt: 1,
+      createdById: 1,
+      updatedById: 1,
+    });
+
+    const b0 = await behaviors.insertOne({
+      test: 1,
+      createdById: userIdToCreate,
+    });
+
+    const b0Object = await behaviors.queryOne(getQueryBody(b0.insertedId));
+
+    assert.equal(b0Object.createdById, userIdToCreate);
 
     const b1 = await behaviors.insertOne(
       {
         test: 1,
+        createdById: userIdToCreate2,
       },
       {
         context: {
@@ -29,19 +52,7 @@ describe("Behaviors", () => {
       }
     );
 
-    const queryBody = {
-      $: {
-        filters: {
-          _id: b1.insertedId,
-        },
-      },
-      createdAt: 1,
-      updatedAt: 1,
-      createdById: 1,
-      updatedById: 1,
-    };
-
-    let b1Object = await behaviors.queryOne(queryBody);
+    let b1Object = await behaviors.queryOne(getQueryBody(b1.insertedId));
 
     assert.instanceOf(b1Object.createdAt, Date);
     assert.instanceOf(b1Object.updatedAt, Date);
@@ -68,7 +79,7 @@ describe("Behaviors", () => {
       }
     );
 
-    b1Object = await behaviors.queryOne(queryBody);
+    b1Object = await behaviors.queryOne(getQueryBody(b1.insertedId));
 
     assert.isTrue(b1Object.updatedAt > b1Object.createdAt);
 

--- a/packages/mongo-bundle/src/behaviors/blameable.ts
+++ b/packages/mongo-bundle/src/behaviors/blameable.ts
@@ -22,7 +22,7 @@ export default function blameable(
     return context[userIdFieldInContext];
   };
 
-  const checkUserId = (userId, collection: Collection<any>) => {
+  const checkUserId = (userId: any, collection: Collection<any>) => {
     if (userId === undefined && throwErrorWhenMissing) {
       throw new Error(
         `You have to provide { userId } inside the context when you perform this insert mutation on ${collection.collectionName} collection.`
@@ -34,8 +34,13 @@ export default function blameable(
     collection.localEventManager.addListener(
       BeforeInsertEvent,
       (e: BeforeInsertEvent) => {
-        const userId = extractUserID(e.data.context);
+        const { context } = e.data;
+
+        const userId = extractUserID(context);
+
         checkUserId(userId, collection);
+
+        if (userId === undefined) return;
 
         const document = e.data.document;
 
@@ -49,8 +54,13 @@ export default function blameable(
     collection.localEventManager.addListener(
       BeforeUpdateEvent,
       (e: BeforeUpdateEvent) => {
-        const userId = extractUserID(e.data.context);
+        const { context } = e.data;
+
+        const userId = extractUserID(context);
+
         checkUserId(userId, collection);
+
+        if (userId === undefined) return;
 
         const update = e.data.update;
 


### PR DESCRIPTION
If we do not have `userId` in the context of the event, the behaviour should _not_ replace `createdById` and `updatedById` (that we may pass in the input).

E.g.:
 
```ts
// I expect `createdById` to be `X`. At the moment, it'll be `null`
await collection.insertOne({
  createdById: "X"
})

// I expect `createdById` to be `Y`
await collection.insertOne({
  createdById: "X"
}, {
  context: {
    userId: "Y"
  }
})
```