### PR TITLE
(fix/di): throw a readable error when service is not found

### DIFF
--- a/packages/core/src/__tests__/DI.test.ts
+++ b/packages/core/src/__tests__/DI.test.ts
@@ -4,6 +4,8 @@ import { Kernel } from "../models/Kernel";
 import { EventManager } from "../models/EventManager";
 import { BundlePhase } from "../defs";
 import { Inject, Service } from "../di";
+import { ContainerInstance } from "..";
+import { ServiceNotFoundError, Token } from "typedi";
 
 describe("DI", () => {
   it("Should work without specifying @Service()", async () => {
@@ -80,5 +82,21 @@ describe("DI", () => {
     expect(
       kernel.container.get(MyService) === kernel.container.get(MyService)
     ).toBe(false);
+  });
+
+  it("should throw a readable error when service is not found", async () => {
+    const kernel = new Kernel({});
+
+    await kernel.init();
+
+    expect(() => kernel.container.get("test")).toThrow(
+      new ServiceNotFoundError("test")
+    );
+
+    const token = new Token("TOKEN_NAME");
+
+    expect(() => kernel.container.get(token)).toThrow(
+      new ServiceNotFoundError("Token<TOKEN_NAME>")
+    );
   });
 });

--- a/packages/core/src/di.ts
+++ b/packages/core/src/di.ts
@@ -7,6 +7,7 @@ import {
   ServiceOptions,
   Constructable,
   ServiceMetadata,
+  Token,
 } from "typedi";
 
 export { Inject, Token } from "typedi";
@@ -76,7 +77,9 @@ export class ContainerInstance extends BaseContainerInstance {
           return super.get(id);
         }
       }
-      console.error(`ServiceNotFoundError for ID: ${id}`);
+      console.error(
+        `ServiceNotFoundError for ID: ${id instanceof Token ? id.name : id}`
+      );
       throw e;
     }
   }


### PR DESCRIPTION
We already know that, if we are trying to get a service by a `class constructor`, even if it's not found, it will first set it in the container, then return it.

If the identifier is a `token` or a `string` and it's not found, we can't do the same, and the error should throw the correct name - `Token<TOKEN_NAME>` if the id is a token, otherwise directly the id.