### PR TITLE
(feat/guardian-smart): add transformUser method

### DIFF
--- a/packages/x-ui-guardian-bundle/src/__tests__/GuardianSmart.test.ts
+++ b/packages/x-ui-guardian-bundle/src/__tests__/GuardianSmart.test.ts
@@ -1,0 +1,16 @@
+import { GuardianSmart, GuardianUserType } from "..";
+import { ObjectId } from "@bluelibs/ejson";
+
+describe("GuardianSmart", () => {
+  test("userId should be objectId", async () => {
+    const guardianSmart = new GuardianSmart();
+
+    const retrieveUserResponse = {
+      _id: "a".repeat(24),
+    } as GuardianUserType;
+
+    const user = guardianSmart.transformUser(retrieveUserResponse);
+
+    expect(user._id).toBeInstanceOf(ObjectId);
+  });
+});

--- a/packages/x-ui-guardian-bundle/src/__tests__/XUIGuardianBundle.test.tsx
+++ b/packages/x-ui-guardian-bundle/src/__tests__/XUIGuardianBundle.test.tsx
@@ -6,7 +6,7 @@ import { XUIGuardianProvider } from "../react/provider";
 import * as TestRenderer from "react-test-renderer";
 import { XUIProvider } from "@bluelibs/x-ui-react-bundle";
 
-describe("UII18NBundle", () => {
+describe("XUIGuardianBundle", () => {
   test("Container Injection", async () => {
     const guardianSmart = container.get(GuardianSmart);
 

--- a/packages/x-ui-guardian-bundle/src/__tests__/index.ts
+++ b/packages/x-ui-guardian-bundle/src/__tests__/index.ts
@@ -1,1 +1,2 @@
+import "./XUIGuardianBundle.test";
 import "./GuardianSmart.test";

--- a/packages/x-ui-guardian-bundle/src/react/smarts/GuardianSmart.ts
+++ b/packages/x-ui-guardian-bundle/src/react/smarts/GuardianSmart.ts
@@ -9,6 +9,7 @@ import {
 } from "../../events";
 import { LOCAL_STORAGE_TOKEN_KEY } from "../../constants";
 import { Smart } from "@bluelibs/smart";
+import { ObjectId } from "@bluelibs/ejson";
 
 export type State<UserType = GuardianUserType> = {
   /**
@@ -158,6 +159,19 @@ export class GuardianSmart<
     await this.load();
   }
 
+  /**
+   * Transforms the user received from retrieveUser().
+   * By default, it only makes _id an ObjectId.
+   * @param user
+   * @returns user
+   */
+  public transformUser(user: TUserType): TUserType {
+    return {
+      ...user,
+      _id: new ObjectId(user._id as any),
+    };
+  }
+
   protected async retrieveUser(): Promise<TUserType> {
     return this.apolloClient
       .query({
@@ -177,7 +191,9 @@ export class GuardianSmart<
         fetchPolicy: "network-only",
       })
       .then((response) => {
-        return response.data.me;
+        const user = response.data.me;
+
+        return this.transformUser(user);
       });
   }
 


### PR DESCRIPTION
Added "transformUser" function on GuardianSmart - by default, it just casts the userId to `ObjectId`. It can be modified. It's called on `retrieveUser()`, before storing the user.


As a side note - how could we really test this? I "simulated" a response from `retrieveUser` (by defining `user = { _id: ... };`), but I guess it'd be best to have some kind of basic BlueLibs API that we can use when we want to test (using mongo-unit for the database, for example).