### PR TITLE
Flexible ways of working with ApolloClient

### DIFF
--- a/packages/x-ui-collections-bundle/DOCUMENTATION.md
+++ b/packages/x-ui-collections-bundle/DOCUMENTATION.md
@@ -508,3 +508,27 @@ const UPDATE_MUTATION = collection.createUpdateMutation(refetchBody);
 
 // useMutation({ mutation: MUTATION })
 ```
+
+:::note
+Delete doesn't have a refetch body option because we assume you will treat this case separately. You can use Mutation options argument in `deleteOne()` to clear the cache of the deleted document manually.
+:::
+
+### Blueprint
+
+Swapping to Apollo cached solution in the "View", "Edit" layers can be done as simple as:
+
+```ts
+const {
+  data: document,
+  loading: isLoading,
+  error,
+} = collection.useQueryOne(EntityViewer.getRequestBody(), {
+  filters: {
+    _id: new ObjectId(props.id),
+  },
+});
+```
+
+Inside table view, the data is fetched inside the ListSmart or AntTableSmart in `x-ui-admin`, which makes it hard to use `useQuery` hook to benefit of data caching.
+
+To solve that, you can either call `tableSmart.load()` after you perform a mutation operation, or fetch the data via `useQuery()` and render your own table. Table smart reacts to page changes, filters, sorting, it smartly refetches every time data changes, doing this via `useQuery()` would mean implying a middleware Component which reads `filters, options` and figure out whether to recall `useQuery()` so you benefit of caching.

--- a/packages/x-ui-collections-bundle/DOCUMENTATION.md
+++ b/packages/x-ui-collections-bundle/DOCUMENTATION.md
@@ -446,14 +446,65 @@ useLiveData(collectionClass, options, body, {
 });
 ```
 
-## Using Apollo
-
-Sometimes if you want to benefit of the Apollo caching, our suggestion is to use the following approach:
-
-```ts
-
-```
-
 :::caution
 When using live data and relations, it is by design to not have reactivity at nested levels. Instead you will have to create separate component that subscribes to that related object via `useLiveData()`.
 :::
+
+## Apollo React Integration
+
+Apollo has a neat way of using `useQuery` and after doing a mutation for a specific type and returns the values, lists get re-rendered.
+
+By default we offer a light-weight approach to data using `useData()`, but depending on your application you might need this caching functions in some places,
+therefore we wanted to offer a seamless solution for this.
+
+```ts
+function Posts() {
+  const collection = use(PostsCollection);
+  const { data, loading, errors } = collection.useQuery(
+    {
+      _id: 1,
+      title: 1,
+      comments: {
+        text: 1,
+      },
+    },
+    {
+      filters: { status: "approved" },
+      options: {
+        // limit, skip, sort
+      },
+    }
+  );
+
+  // data will be Post[] directly
+}
+```
+
+For working with single data relations please use `collection.useQueryOne()` having the exact same api, except `data` is going to be `Post` instead of `Post[]`.
+
+When you perform a mutation, you can now trigger the cache, by doing so:
+
+```ts
+collection.updateOne(
+  post._id,
+  {
+    title: "My New Title",
+  },
+  // Refetch Body:
+  {
+    // _id: 1 is auto-populated
+    title: 1,
+  }
+);
+
+// Same concept applies to insertOne.
+```
+
+If you want to use `useMutation()` from Apollo for various reasons we expose the following helper functions:
+
+```ts
+const INSERT_MUTATION = collection.createInsertMutation(refetchBody);
+const UPDATE_MUTATION = collection.createUpdateMutation(refetchBody);
+
+// useMutation({ mutation: MUTATION })
+```

--- a/packages/x-ui-collections-bundle/DOCUMENTATION.md
+++ b/packages/x-ui-collections-bundle/DOCUMENTATION.md
@@ -446,6 +446,14 @@ useLiveData(collectionClass, options, body, {
 });
 ```
 
+## Using Apollo
+
+Sometimes if you want to benefit of the Apollo caching, our suggestion is to use the following approach:
+
+```ts
+
+```
+
 :::caution
 When using live data and relations, it is by design to not have reactivity at nested levels. Instead you will have to create separate component that subscribes to that related object via `useLiveData()`.
 :::

--- a/packages/x-ui-collections-bundle/package.json
+++ b/packages/x-ui-collections-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluelibs/x-ui-collections-bundle",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": false,
   "description": "XUICollectionsBundle",
   "main": "dist/index.js",

--- a/packages/x-ui-collections-bundle/src/__tests__/Collection.test.ts
+++ b/packages/x-ui-collections-bundle/src/__tests__/Collection.test.ts
@@ -1,6 +1,9 @@
 import { Collection } from "..";
 import { container } from "./ecosystem";
-import { CollectionTransformMap } from "../graphql/Collection";
+import {
+  CollectionTransformMap,
+  CollectionLinkConfig,
+} from "../graphql/Collection";
 import { EJSON } from "@bluelibs/ejson";
 import { richResponse, richResponseBody } from "./samples/richResponse";
 import { cleanTypename } from "../graphql/utils/cleanTypename";
@@ -38,7 +41,7 @@ describe("XUICollectionsBundle", () => {
         };
       }
 
-      getLinks() {
+      getLinks(): CollectionLinkConfig<any>[] {
         return [
           {
             collection: () => AppFileGroupsCollection,

--- a/packages/x-ui-collections-bundle/src/graphql/Collection.ts
+++ b/packages/x-ui-collections-bundle/src/graphql/Collection.ts
@@ -5,12 +5,23 @@ import {
   Constructor,
 } from "@bluelibs/core";
 import { jsonToGraphQLQuery, VariableType } from "json-to-graphql-query";
-import { gql, DocumentNode, FetchPolicy } from "@apollo/client/core";
+import {
+  gql,
+  FetchPolicy,
+  MutationOptions,
+  DocumentNode,
+} from "@apollo/client/core";
 import { EJSON, ObjectId } from "@bluelibs/ejson";
 import { IQueryInput, ISubscriptionOptions, QueryBodyType } from "./defs";
 import { getSideBody } from "./utils/getSideBody";
 import { cleanTypename } from "./utils/cleanTypename";
 import { ApolloClient } from "@bluelibs/ui-apollo-bundle";
+import {
+  OperationVariables,
+  QueryOptions as ApolloQueryOptions,
+  QueryResult as ApolloQueryResult,
+  useQuery as baseUseQuery,
+} from "@apollo/client";
 
 type CompiledQueriesTypes = "Count" | "InsertOne" | "UpdateOne" | "DeleteOne";
 
@@ -25,7 +36,7 @@ export type CollectionTransformMap<T> = Partial<{
 }>;
 
 export type CollectionLinkConfig<T> = {
-  collection: (container) => Constructor<Collection>;
+  collection: (container) => Constructor<Collection<T>>;
   name: keyof T;
   many?: boolean;
   field?: keyof T;
@@ -163,21 +174,24 @@ export abstract class Collection<T = null> {
    * Insert a single document into the remote database
    * @param document
    */
-  async insertOne(document: Partial<T>): Promise<Partial<T>> {
-    const insertInput = this.getInputs().insert || "EJSON!";
+  async insertOne(
+    document: Partial<T>,
+    refetchBody?: QueryBodyType<T>,
+    options?: MutationOptions
+  ): Promise<Partial<T>> {
+    const mutation = this.createInsertMutation(refetchBody);
 
-    if (insertInput === "EJSON!") {
-      return this.runCompiledQuery("InsertOne", {
-        document: EJSON.stringify(document),
+    return this.apolloClient
+      .mutate({
+        ...options,
+        mutation,
+        variables: {
+          document,
+        },
+      })
+      .then((response) => {
+        return response.data[`${this.getName()}InsertOne`];
       });
-    } else {
-      const newDocument = Object.assign({}, document);
-      this.serialize(newDocument);
-
-      return this.runCompiledQuery("InsertOne", {
-        document: newDocument,
-      });
-    }
   }
 
   /**
@@ -187,40 +201,57 @@ export abstract class Collection<T = null> {
    */
   async updateOne(
     _id: ObjectId | string,
-    modifier: UpdateFilter<T> | TransformPartial<T>
+    update: UpdateFilter<T> | TransformPartial<T>,
+    refetchBody?: QueryBodyType<T>,
+    options?: MutationOptions
   ): Promise<Partial<T>> {
-    const updateInput = this.getInputs().update || "EJSON!";
-
-    if (updateInput === "EJSON!") {
-      return this.runCompiledQuery("UpdateOne", {
-        _id,
-        modifier: EJSON.stringify(modifier),
-      });
-    } else {
-      let document: TransformPartial<T>;
-      if (this.isUpdateModifier(modifier)) {
-        document = modifier["$set"];
-      } else {
-        document = modifier;
-      }
-      const newDocument = Object.assign({}, document);
-      this.serialize(newDocument);
-
-      return this.runCompiledQuery("UpdateOne", {
-        _id,
-        document: newDocument,
-      });
+    // @ts-ignore
+    if (refetchBody && !refetchBody._id) {
+      // @ts-ignore
+      refetchBody._id = 1;
     }
+    const mutation = this.createUpdateMutation(refetchBody);
+
+    const updateType = this.getInputs().update || "EJSON!";
+    const updateTypeVariable =
+      updateType === "EJSON!" ? "modifier" : "document";
+
+    return this.apolloClient
+      .mutate({
+        ...options,
+        mutation,
+        variables: {
+          _id,
+          [updateTypeVariable]: update,
+        },
+      })
+      .then((response) => {
+        return response.data[`${this.getName()}UpdateOne`];
+      });
   }
 
   /**
    * Delete a single element by _id from database
    * @param _id
    */
-  async deleteOne(_id: ObjectId | string): Promise<boolean> {
-    return this.runCompiledQuery("DeleteOne", {
-      _id,
-    });
+  async deleteOne(
+    _id: ObjectId | string,
+    options?: MutationOptions
+  ): Promise<boolean> {
+    const mutation = this.createDeleteMutation();
+
+    return this.apolloClient
+      .mutate({
+        ...options,
+        mutation,
+        variables: {
+          _id,
+          document,
+        },
+      })
+      .then((response) => {
+        return response.data[`${this.getName()}DeleteOne`];
+      });
   }
 
   /**
@@ -333,6 +364,8 @@ export abstract class Collection<T = null> {
       },
     };
 
+    // Side body is a way to pass nested collection filters, options
+    // Gets merged back on the server
     if (queryInput?.options) {
       const sideBody = getSideBody(body);
       if (Object.keys(sideBody).length > 0) {
@@ -386,10 +419,12 @@ export abstract class Collection<T = null> {
       compiledQuery
     );
 
+    const graphqlExecutor = this.compiled.get(compiledQuery);
+
     if (isMutation) {
       return this.apolloClient
         .mutate({
-          mutation: this.compiled.get(compiledQuery),
+          mutation: graphqlExecutor,
           variables,
           ...options,
         })
@@ -400,7 +435,7 @@ export abstract class Collection<T = null> {
 
     return this.apolloClient
       .query({
-        query: this.compiled.get(compiledQuery),
+        query: graphqlExecutor,
         variables,
         fetchPolicy: this.getFetchPolicy(),
         ...options,
@@ -417,6 +452,10 @@ export abstract class Collection<T = null> {
    * @returns
    */
   createInsertMutation(body?: QueryBodyType<T>): DocumentNode {
+    if (!body) {
+      return this.compiled.get("InsertOne");
+    }
+
     const insertType = this.getInputs().insert || "EJSON!";
     const operationName = `${this.getName()}InsertOne`;
 
@@ -444,6 +483,10 @@ export abstract class Collection<T = null> {
    * @returns
    */
   createUpdateMutation(body?: QueryBodyType<T>): DocumentNode {
+    if (!body) {
+      return this.compiled.get("UpdateOne");
+    }
+
     const updateType = this.getInputs().update || "EJSON!";
     const operationName = `${this.getName()}UpdateOne`;
 
@@ -476,23 +519,91 @@ export abstract class Collection<T = null> {
    * @returns
    */
   createDeleteMutation(): DocumentNode {
-    const operationName = `${this.getName()}DeleteOne`;
+    return this.compiled.get("DeleteOne");
 
-    const graphQLQuery = {
-      mutation: {
-        __name: operationName,
-        __variables: {
-          _id: "ObjectId!",
-        },
-        [operationName]: {
-          __args: {
-            _id: new VariableType("_id"),
-          },
-        },
+    // In case we'll need custom things later
+    // const operationName = `${this.getName()}DeleteOne`;
+
+    // const graphQLQuery = {
+    //   mutation: {
+    //     __name: operationName,
+    //     __variables: {
+    //       _id: "ObjectId!",
+    //     },
+    //     [operationName]: {
+    //       __args: {
+    //         _id: new VariableType("_id"),
+    //       },
+    //     },
+    //   },
+    // };
+
+    // return gql(jsonToGraphQLQuery(graphQLQuery));
+  }
+
+  /**
+   * Integration with native `useQuery` from Apollo, offering a hybrid approach so apollo re-uses your cache.
+   * Please note that we also return as data the actual documents and not the main data object.
+   *
+   * For finding a single element, refer to useQueryOne.
+   */
+  public useQuery<TVariables = OperationVariables>(
+    body: QueryBodyType<T>,
+    queryInput: IQueryInput<T>,
+    options?: ApolloQueryOptions
+  ): ApolloQueryResult<T[], TVariables> {
+    // This is done on every re-render, maybe we could useMemo() some
+
+    const [QUERY, prepareSideBody] = this.createFindQuery(false, body);
+
+    // side body used for nested collections filtering
+    queryInput = prepareSideBody(queryInput);
+    const operation = this.getName() + "Find";
+
+    const result = baseUseQuery<T[], any>(QUERY, {
+      ...options,
+      query: QUERY,
+      variables: {
+        query: queryInput,
       },
-    };
+    });
 
-    return gql(jsonToGraphQLQuery(graphQLQuery));
+    if (result?.data) {
+      result.data = result.data[operation] || [];
+    }
+
+    return result;
+  }
+
+  /**
+   * Integration with native `useQuery` from Apollo, offering a hybrid approach so apollo re-uses your cache.
+   */
+  public useQueryOne<TVariables = OperationVariables>(
+    body: QueryBodyType<T>,
+    queryInput: IQueryInput<T>,
+    options?: ApolloQueryOptions
+  ): ApolloQueryResult<T, TVariables> {
+    // This is done on every re-render, maybe we could useMemo() some
+
+    const [QUERY, prepareSideBody] = this.createFindQuery(true, body);
+
+    // side body used for nested collections filtering
+    queryInput = prepareSideBody(queryInput);
+    const operation = this.getName() + "FindOne";
+
+    const result = baseUseQuery<T, any>(QUERY, {
+      ...options,
+      query: QUERY,
+      variables: {
+        query: queryInput,
+      },
+    });
+
+    if (result?.data) {
+      result.data = result.data[operation] || [];
+    }
+
+    return result;
   }
 
   /**
@@ -504,7 +615,7 @@ export abstract class Collection<T = null> {
   public createFindQuery<T = null>(
     single: boolean,
     body: QueryBodyType<T>
-  ): [DocumentNode, Function] {
+  ): [DocumentNode, (queryInput: IQueryInput<T>) => IQueryInput<T>] {
     const operationName = this.getName() + (single ? "FindOne" : "Find");
 
     const graphQLQuery = {
@@ -520,7 +631,7 @@ export abstract class Collection<T = null> {
       },
     };
 
-    const prepare = (queryInput: IQueryInput) => {
+    const prepare = (queryInput: IQueryInput<T>) => {
       const options = Object.assign({}, queryInput.options);
       const filters = Object.assign({}, queryInput.filters);
 

--- a/packages/x-ui-collections-bundle/src/graphql/defs.ts
+++ b/packages/x-ui-collections-bundle/src/graphql/defs.ts
@@ -1,3 +1,5 @@
+import { IEventsMap } from "@bluelibs/ui-apollo-bundle";
+
 type Filter<T = any> = {
   [key: string]: any;
 };
@@ -64,3 +66,32 @@ export type QueryBodyType<T = null> = BodyCustomise<T> &
 
 export type QuerySubBodyType<T = null> = BodyCustomise<T> &
   (T extends null ? AnyBody : RootSpecificBody<T>);
+
+export interface IQueryInput<T = null> {
+  /**
+   * MongoDB Filters
+   * @url https://docs.mongodb.com/manual/reference/operator/query/
+   */
+  filters?: T extends null
+    ? {
+        [key: string]: any;
+      }
+    : Filter<T>;
+  /**
+   * MongoDB Options
+   */
+  options?: IQueryOptionsInput;
+}
+
+export interface ISubscriptionOptions extends IEventsMap {
+  subscription?: string;
+}
+
+export interface IQueryOptionsInput {
+  sort?: {
+    [key: string]: any;
+  };
+  limit?: number;
+  skip?: number;
+  sideBody?: QueryBodyType;
+}

--- a/packages/x-ui-collections-bundle/src/react/hooks/useData.ts
+++ b/packages/x-ui-collections-bundle/src/react/hooks/useData.ts
@@ -1,9 +1,10 @@
 import { useState, useEffect, useMemo } from "react";
 import { Constructor } from "@bluelibs/core";
-import { Collection, IQueryInput } from "../../graphql/Collection";
-import { QueryBodyType } from "../../graphql/defs";
+import { Collection } from "../../graphql/Collection";
+import { IQueryInput, QueryBodyType } from "../../graphql/defs";
 
 import { use } from "@bluelibs/x-ui-react-bundle";
+import { QueryHookOptions } from "@apollo/client";
 
 type RefetchType = () => Promise<void>;
 

--- a/packages/x-ui-collections-bundle/src/react/hooks/useLiveData.ts
+++ b/packages/x-ui-collections-bundle/src/react/hooks/useLiveData.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect } from "react";
 import { Constructor } from "@bluelibs/core";
-import { Collection, IQueryInput } from "../../graphql/Collection";
-import { ISubscriptionOptions } from "../../graphql/Collection";
-import { QueryBodyType } from "../../graphql/defs";
+import { Collection } from "../../graphql/Collection";
+import {
+  IQueryInput,
+  ISubscriptionOptions,
+  QueryBodyType,
+} from "../../graphql/defs";
 import { use } from "@bluelibs/x-ui-react-bundle";
 import { XSubscription } from "@bluelibs/ui-apollo-bundle";
 

--- a/packages/x-ui-collections-bundle/src/react/hooks/useSubscription.ts
+++ b/packages/x-ui-collections-bundle/src/react/hooks/useSubscription.ts
@@ -2,8 +2,7 @@ import { useState, useEffect } from "react";
 import Observable from "zen-observable";
 import { Constructor } from "@bluelibs/core";
 import { Collection } from "../../graphql/Collection";
-import { ISubscriptionOptions } from "../..//graphql/Collection";
-import { QueryBodyType } from "../../graphql/defs";
+import { ISubscriptionOptions, QueryBodyType } from "../../graphql/defs";
 import { XSubscription } from "@bluelibs/ui-apollo-bundle";
 import { use } from "@bluelibs/x-ui-react-bundle";
 

--- a/packages/x/templates/microservice/backend/package.json
+++ b/packages/x/templates/microservice/backend/package.json
@@ -51,6 +51,7 @@
     "react-dom": "^17.0.1",
     "passport": "^0.4.1",
     "moment": "^2.29.1",
+    "mongodb": "4.2.2",
     "yup": "^0.32.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] Setup queries to work with the createInsertMutation, etc
- [x] Implement useQuery() inside useData() so we benefit of caching
- [ ] Integration tests