### PR TITLE
feat(apollo-hooks): improve useQuery & useMutation API

### DIFF
--- a/packages/x-ui-collections-bundle/DOCUMENTATION.md
+++ b/packages/x-ui-collections-bundle/DOCUMENTATION.md
@@ -473,10 +473,20 @@ function Posts() {
       options: {
         // limit, skip, sort
       },
+    },
+    {
+      // This is an optional argument
+      apollo: {
+        // Pass here any additional Apollo query option you may need
+        // https://www.apollographql.com/docs/react/data/queries/#usequery-api
+        fetchPolicy: "network-only",
+      },
     }
   );
 
   // data will be Post[] directly
+
+  // Same concept applies to useQueryOne, useLazyQuery and useLazyQueryOne.
 }
 ```
 
@@ -490,10 +500,18 @@ collection.updateOne(
   {
     title: "My New Title",
   },
-  // Refetch Body:
   {
-    // _id: 1 is auto-populated
-    title: 1,
+    refetchBody: {
+      title: 1,
+      // _id: 1 is auto-populated
+    },
+
+    apollo: {
+      // This is an optional argument
+      // Pass here any additional Apollo mutation option you may need
+      // https://www.apollographql.com/docs/react/data/mutations/#usemutation-api
+      refetchQueries: ["PostsFind"],
+    },
   }
 );
 

--- a/packages/x-ui-collections-bundle/src/graphql/Collection.ts
+++ b/packages/x-ui-collections-bundle/src/graphql/Collection.ts
@@ -59,6 +59,20 @@ export type CollectionInputsConfig = {
   update?: string;
 };
 
+export interface UseQueryOptions {
+  apollo: Omit<ApolloQueryOptions, "query">;
+}
+
+export interface InsertOneOptions<T> {
+  refetchBody?: QueryBodyType<T>;
+  apollo: Omit<MutationOptions, "mutation">;
+}
+
+export interface UpdateOneOptions<T> {
+  refetchBody?: QueryBodyType<T>;
+  apollo: Omit<MutationOptions, "mutation">;
+}
+
 @Service()
 export abstract class Collection<T = null> {
   compiled = new Map<CompiledQueriesTypes, DocumentNode>();
@@ -188,9 +202,9 @@ export abstract class Collection<T = null> {
    */
   async insertOne(
     document: Partial<T>,
-    refetchBody?: QueryBodyType<T>,
-    options?: MutationOptions
+    options?: InsertOneOptions<T>
   ): Promise<Partial<T>> {
+    const { apollo, refetchBody } = options;
     const mutation = this.createInsertMutation(refetchBody);
     const insertInput = this.getInputs().insert || "EJSON!";
 
@@ -204,7 +218,7 @@ export abstract class Collection<T = null> {
 
     return this.apolloClient
       .mutate({
-        ...options,
+        ...apollo,
         mutation,
         variables: {
           document: mutationDocument,
@@ -223,9 +237,10 @@ export abstract class Collection<T = null> {
   async updateOne(
     _id: ObjectId | string,
     update: UpdateFilter<T> | TransformPartial<T>,
-    refetchBody?: QueryBodyType<T>,
-    options?: MutationOptions
+    options?: UpdateOneOptions<T>
   ): Promise<Partial<T>> {
+    const { apollo, refetchBody } = options;
+
     // @ts-ignore
     if (refetchBody && !refetchBody._id) {
       // @ts-ignore
@@ -253,7 +268,7 @@ export abstract class Collection<T = null> {
 
     return this.apolloClient
       .mutate({
-        ...options,
+        ...apollo,
         mutation,
         variables: {
           _id,
@@ -582,14 +597,21 @@ export abstract class Collection<T = null> {
    *
    * For finding a single element, refer to useQueryOne.
    */
-  public useQuery<TVariables = OperationVariables>(
-    body: QueryBodyType<T>,
-    queryInput: IQueryInput<T>,
-    options?: ApolloQueryOptions
-  ): ApolloQueryResult<T[], TVariables> {
+  public useQuery<TVariables = OperationVariables>({
+    body = { _id: 1 },
+    queryInput,
+    options,
+  }: {
+    body?: QueryBodyType<T> | { _id: number }; // Might be more elegant
+    queryInput: IQueryInput<T>;
+    options?: UseQueryOptions;
+  }): ApolloQueryResult<T[], TVariables> {
     // This is done on every re-render, maybe we could useMemo() some
 
-    const [QUERY, prepareSideBody] = this.createFindQuery(false, body);
+    const [QUERY, prepareSideBody] = this.createFindQuery(
+      false,
+      body as QueryBodyType<T>
+    );
 
     // side body used for nested collections filtering
     queryInput = prepareSideBody(queryInput);
@@ -613,14 +635,21 @@ export abstract class Collection<T = null> {
   /**
    * Integration with native `useQuery` from Apollo, offering a hybrid approach so apollo re-uses your cache.
    */
-  public useQueryOne<TVariables = OperationVariables>(
-    body: QueryBodyType<T>,
-    queryInput: IQueryInput<T>,
-    options?: ApolloQueryOptions
-  ): ApolloQueryResult<T, TVariables> {
+  public useQueryOne<TVariables = OperationVariables>({
+    body = { _id: 1 },
+    queryInput,
+    options,
+  }: {
+    body?: QueryBodyType<T> | { _id: number }; // Might be more elegant
+    queryInput: IQueryInput<T>;
+    options?: UseQueryOptions;
+  }): ApolloQueryResult<T, TVariables> {
     // This is done on every re-render, maybe we could useMemo() some
 
-    const [QUERY, prepareSideBody] = this.createFindQuery(true, body);
+    const [QUERY, prepareSideBody] = this.createFindQuery(
+      true,
+      body as QueryBodyType<T>
+    );
 
     // side body used for nested collections filtering
     queryInput = prepareSideBody(queryInput);
@@ -655,6 +684,7 @@ export abstract class Collection<T = null> {
 
     const graphQLQuery = {
       query: {
+        __name: operationName,
         __variables: {
           query: "QueryInput!",
         },


### PR DESCRIPTION
- Modify `collection.useQuery` and `collection.useMutation` signatures so they accept a single structured param instead of list of ordered params
- Set a query name to queries. By default, the same as the operationName, but can be customized by the developper. It allow refetching through query name string
- Set a default value to query bodies as `{ _id: 1 }`, making them optional
- Omit `query` and `mutation` from default apollo query and mutation options to avoid typescript to yell because of missing param, as it it directly provided by the `collection.use[query|mutation]`

Regarding setting `{ _id: 1 }` as default body, typescript was rasing an error as it considers the default value does not match overlap with `QueryBodyType<T>`, so I had to go for `body?: QueryBodyType<T> | { _id: number },`. Surely we can do more elegant than this.