### PR TITLE
Fix/UI session storage set

### DIFF
--- a/packages/x-ui-session-bundle/src/react/services/UISessionStorage.ts
+++ b/packages/x-ui-session-bundle/src/react/services/UISessionStorage.ts
@@ -31,22 +31,26 @@ export class UISessionStorage {
   }
 
   setItem(key: string, value: any) {
-    this.storage.setItem(key, value);
+    this.storage.setItem(key, EJSON.stringify(value));
   }
 
   getItem(key: string) {
     const value = this.storage.getItem(key);
 
-    if (typeof value === "string") {
+    try {
       return EJSON.parse(value);
+    } catch (_) {
+      return value;
     }
-
-    return value;
   }
 
   all() {
     if (this.executionContext === ExecutionContext.WEB) {
-      return { ...this.storage };
+      const store = { ...localStorage };
+
+      Object.keys(store).forEach((key) => (store[key] = this.getItem(key)));
+
+      return store;
     } else {
       return (this.storage as DummyLocalStorage).all();
     }

--- a/packages/x-ui-session-bundle/src/react/services/UISessionStorage.ts
+++ b/packages/x-ui-session-bundle/src/react/services/UISessionStorage.ts
@@ -31,7 +31,7 @@ export class UISessionStorage {
   }
 
   setItem(key: string, value: any) {
-    this.storage.setItem(key, EJSON.stringify(value));
+    this.storage.setItem(key, value);
   }
 
   getItem(key: string) {


### PR DESCRIPTION
Before, we were getting the key-values from localStorage with `{ ...localStorage }` - hence, we were not parsing the value.

I added a try-catch in `getItem` - so that, if the value is parsable (e.g. it's a stringified object / a number) - it returns `EJSON.parse(value)`, otherwise (e.g. it's a string) it directly returns the value.

In `all()`, I parse all the values in `{ ...localStorage }` with `getItem`.