### PR TITLE
fix x and x-ui-admin: allow representedBy to be nested

### DIFF
--- a/packages/x-ui-admin/src/react/components/AdminListItemRenderer.tsx
+++ b/packages/x-ui-admin/src/react/components/AdminListItemRenderer.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { DownloadOutlined } from "@ant-design/icons";
 import * as startCase from "lodash.startcase";
 import { ObjectId } from "@bluelibs/ejson";
-
+import * as _ from "lodash";
 const emptyValue = "N/A";
 
 export type AdminListItemRendererProps = {
@@ -121,7 +121,9 @@ export function AdminListItemRenderer(props: AdminListItemRendererProps) {
 
     value = (
       <Link to={props.relation.path}>
-        <Tag>{props.value[props.relation.dataIndex]}</Tag>
+        <Tag>
+          {_.get(props.value, props.relation.dataIndex.split("."), emptyValue)}
+        </Tag>
       </Link>
     );
   }

--- a/packages/x-ui-admin/src/react/components/RemoteSelect.tsx
+++ b/packages/x-ui-admin/src/react/components/RemoteSelect.tsx
@@ -3,6 +3,7 @@ import { Constructor } from "@bluelibs/core";
 import { Collection, use, useData } from "@bluelibs/x-ui";
 import { Alert, Select, SelectProps, Spin } from "antd";
 import { ObjectId } from "@bluelibs/ejson";
+import * as _ from "lodash";
 
 export type RemoteSelectProps = SelectProps<any> & {
   collectionClass: Constructor<Collection<any>>;
@@ -33,10 +34,7 @@ export function RemoteSelect(props: RemoteSelectProps) {
   const { data, isLoading, error } = useData(
     props.collectionClass,
     {},
-    {
-      _id: 1,
-      [props.field]: 1,
-    }
+    _.set({ _id: 1 }, field.split("."), 1)
   );
 
   if (isLoading) {
@@ -48,7 +46,7 @@ export function RemoteSelect(props: RemoteSelectProps) {
 
   const options = data.map((d) => (
     <Select.Option key={d._id.toString()} value={d._id.toString()}>
-      {d[props.field] ? d[props.field].toString() : "N/A"}
+      {_.get(d, field.split("."), "N/A").toString()}
     </Select.Option>
   ));
 

--- a/packages/x/src/models/UICRUDModel.ts
+++ b/packages/x/src/models/UICRUDModel.ts
@@ -104,10 +104,19 @@ export class UICRUDModel {
     this.recursiveBodyExpand(mode, body, this.studioCollection.fields);
 
     this.studioCollection.getRelationshipsByUIMode(mode).forEach((r) => {
-      body[r.id] = {
-        _id: 1,
-        [r.cleaned.representedBy.id]: 1,
-      };
+      if (Array.isArray(r.cleaned.representedBy)) {
+        body[r.id] = _.set(
+          { _id: 1 },
+          r.cleaned.representedBy.map((x) => x.id),
+          1
+        );
+      } else {
+        body[r.id] = {
+          _id: 1,
+          [r.cleaned.representedBy.id]: 1,
+        };
+      }
+
       if (r.isDirect) {
         body[r.cleaned.field.id] = 1;
       }
@@ -337,7 +346,9 @@ export class UICRUDModel {
       key: relation.id,
       isMany: relation.isMany,
       sorter: true,
-      remoteField: relation.representedBy.id,
+      remoteField: Array.isArray(relation.representedBy)
+        ? relation.representedBy.map((x) => x.id).join(".")
+        : relation.representedBy.id,
       routeName: this.generateRouteNameForCollection(relation.to.id, "view"),
       relational: true,
       remoteCollectionClass: relation.to.id + "Collection",

--- a/packages/x/src/studio/models/App.ts
+++ b/packages/x/src/studio/models/App.ts
@@ -22,11 +22,28 @@ export class BaseModel<T = null> {
       return this.app.collections.find((c) => c.id === id);
     },
 
-    field: (collectionId: string, id: string): Field => {
+    //return field or array of fields in case the id was nested path as 'key1.key2.key3'=>[field1,field2,field3]
+    field: (collectionId: string, id: string): Field | Field[] => {
       const collection = this.find.collection(collectionId);
-      const f = collection.fields.find((f) => f.id === id);
-
-      return f;
+      let fieldsPathIds = id.split(".");
+      if (fieldsPathIds.length === 1) {
+        return collection.fields.find((f) => f.id === id);
+      } else {
+        //we wanna return all the fields that represent the path to the nested attribut field1:{subfield:[field2:{}]}
+        let headField = collection.fields.find(
+          (f) => f.id === fieldsPathIds[0]
+        );
+        let arrayFields = [headField];
+        fieldsPathIds = fieldsPathIds.slice(1);
+        for (let fieldId of fieldsPathIds) {
+          if (headField?.subfields && headField?.subfields.length > 0) {
+            let subField = headField.subfields.find((sf) => sf.id == fieldId);
+            arrayFields.push(subField);
+            headField = subField;
+          } else break;
+        }
+        return arrayFields;
+      }
     },
 
     model: (id: string): SharedModel => {

--- a/packages/x/src/studio/models/Collection.ts
+++ b/packages/x/src/studio/models/Collection.ts
@@ -47,7 +47,7 @@ export class Collection extends BaseModel<Collection> {
    * When other collections relate to this, we need a toString() version of this collection document.
    * This can be a field reducer or an actual field, like "fullName" for `User`, or "name" for `Project`
    */
-  representedBy: Resolvable<Field>;
+  representedBy: Resolvable<Field | Field[]>;
 
   /**
    * Collections which have an external package are not written, they exist only to be able to properly link with them.

--- a/packages/x/src/studio/models/Relation.ts
+++ b/packages/x/src/studio/models/Relation.ts
@@ -53,7 +53,7 @@ export class Relation extends BaseModel<Relation> {
    * For example, if I have Post relating to User, user is represented by "fullName"
    * @cleanable
    */
-  representedBy?: Resolvable<Field>;
+  representedBy?: Resolvable<Field | Field[]>;
 
   /**
    * Mocking information, how many should we generate?

--- a/packages/x/src/studio/models/SharedModel.ts
+++ b/packages/x/src/studio/models/SharedModel.ts
@@ -27,7 +27,7 @@ export class SharedModel extends BaseModel<SharedModel> {
   /**
    * By which field it's going to be represented?
    */
-  representedBy?: Resolvable<Field>;
+  representedBy?: Resolvable<Field | Field[]>;
 
   /**
    * Whether this collection is something users can see


### PR DESCRIPTION
fixed the [https://github.com/bluelibs/bluelibs/issues/169](issue 169),
allowing the representedBy to be nested, example: representedBy ='profile.job.jobTitle'
fixes #169