### PR TITLE
fix x-bundle: objectId isValid returning false of objectId

### DIFF
--- a/packages/x-bundle/src/validators/ObjectId.validator.ts
+++ b/packages/x-bundle/src/validators/ObjectId.validator.ts
@@ -18,7 +18,7 @@ export class ObjectIdSchema extends yup.BaseSchema<any> {
 
   protected _typeCheck(_value: any): _value is NonNullable<any> {
     try {
-      return ObjectId.isValid(_value);
+      return ObjectId.isValid(_value) || ObjectId.isValid(_value.toString());
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
the isValid on object id return true on string id, but not for ObjectId
fixes #225