### PR TITLE
(update): allow passing an array of [path, ...middlewares] as middleware

### DIFF
--- a/packages/apollo-bundle/src/ApolloBundle.ts
+++ b/packages/apollo-bundle/src/ApolloBundle.ts
@@ -158,8 +158,8 @@ export class ApolloBundle extends Bundle<ApolloBundleConfigType> {
       app.use(express.json());
     }
 
-    if (this.config.middlewares.length) {
-      app.use(...this.config.middlewares);
+    for (const middleware of this.config.middlewares) {
+      app.use.apply(app, Array.isArray(middleware) ? middleware : [middleware]);
     }
 
     this.app = app;

--- a/packages/apollo-bundle/src/defs.ts
+++ b/packages/apollo-bundle/src/defs.ts
@@ -3,13 +3,14 @@ import * as express from "express";
 import { ExecutionParams } from "subscriptions-transport-ws";
 import { ContainerInstance } from "@bluelibs/core";
 import { UploadOptions } from "graphql-upload";
+import { RequestHandler } from "express";
 
 export type ApolloBundleConfigType = {
   port?: number;
   url?: string;
   apollo?: ApolloServerExpressConfig;
   enableSubscriptions?: boolean;
-  middlewares?: any[];
+  middlewares?: RequestHandler[];
   routes?: IRouteType[];
   uploads?: false | UploadOptions;
   /**


### PR DESCRIPTION
Idea: the way this was working before, you could only pass middlewares that applied for every route, e.g.:

```
middlewares: [
  cors(),
  ...
]
```

But, if you wanted for example to apply a middleware only to a certain path, it wouldn't work. This way, you can pass in:

```
middlewares: [
  cors(),
  ["/test", someMiddleware()],
  ["/another-test", [middleware1(), middleware2()]
]
```


Real use case: stripe webhooks need to have a "rawBody" on the request. By default, express doesn't have that. You need to use a middleware. And you don't want to use this middleware on any other router, other than the one for the webhook - because it's basically using 2x the memory. Hence, you could now do:

```
middlewares: [
  ["/stripe/webhooks", addRawBody],
  express.json(),
]
```