### PR TITLE
fix(x-ui): remove document from deleteOne

### DIFF
--- a/packages/x-ui-collections-bundle/src/graphql/Collection.ts
+++ b/packages/x-ui-collections-bundle/src/graphql/Collection.ts
@@ -362,7 +362,6 @@ export abstract class Collection<T = null> {
         mutation,
         variables: {
           _id,
-          document,
         },
       })
       .then((response) => {


### PR DESCRIPTION
It's reading the HTML document, inducing a cyclic error in apollo client. This is common & important enough to be caugth in a a unit test :)

Found by https://github.com/matthieujabbour/