### PR TITLE
fix(ui-collection): fix useQueryOne

### DIFF
--- a/packages/x-ui-collections-bundle/src/graphql/Collection.ts
+++ b/packages/x-ui-collections-bundle/src/graphql/Collection.ts
@@ -765,7 +765,7 @@ export abstract class Collection<T = null> {
     });
 
     if (result?.data) {
-      result.data = result.data[operation] || [];
+      result.data = result.data || null;
     }
 
     return result;

--- a/packages/x/src/models/GraphQLCRUDModel.ts
+++ b/packages/x/src/models/GraphQLCRUDModel.ts
@@ -2,6 +2,7 @@ import { GenericModel } from "./GenericModel";
 import { IXElementResult, XElements, XElementType } from "../utils/XElements";
 import { ModelRaceEnum } from "./defs";
 import * as path from "path";
+import { CrudGenerator } from "../studio";
 
 export class GraphQLCRUDModel {
   bundleName: string;
@@ -15,6 +16,7 @@ export class GraphQLCRUDModel {
   insertInputModelDefinition: GenericModel;
   updateInputModelDefinition: GenericModel;
   hasSubscriptions: boolean = false;
+  crudOperations: CrudGenerator;
 
   get collectionClass() {
     return this.collectionElement.identityName;

--- a/packages/x/src/studio/StudioWriter.ts
+++ b/packages/x/src/studio/StudioWriter.ts
@@ -412,7 +412,7 @@ export class StudioWriter {
     const microservicePath = session.getMicroservicePath();
     const crudWriter = this.writers.graphQLCRUD;
     for (const collection of studioApp.collections) {
-      if (!collection.hasGraphQL("crud")) {
+      if (!collection.hasGraphQL("crud") || !collection.crud) {
         continue;
       }
       if (collection.isExternal()) {
@@ -423,6 +423,7 @@ export class StudioWriter {
       model.checkLoggedIn = false;
       model.hasSubscriptions = true;
       model.crudName = collection.id;
+      model.crudOperations = collection.crud;
       model.collectionElement = XElements.emulateElement(
         microservicePath,
         "AppBundle",

--- a/packages/x/src/studio/defs.ts
+++ b/packages/x/src/studio/defs.ts
@@ -14,10 +14,9 @@ export type Resolved<T> = {
   [K in keyof T]: T[K] extends Resolvable<infer Q> ? Q : T[K];
 };
 
-export type RequireFields<T, K extends (keyof T)[]> = DeepPartial<T> &
-  {
-    [Z in K[number]]: T[Z];
-  };
+export type RequireFields<T, K extends (keyof T)[]> = DeepPartial<T> & {
+  [Z in K[number]]: T[Z];
+};
 
 export type FactoryFunction<T, RT extends (keyof T)[] = null> = (
   data: RequireFields<T, RT>
@@ -49,6 +48,20 @@ export type UICollectionConfigType =
        */
       icon?: string;
     } & UIModeConfigType);
+
+export type CrudGenerator =
+  | {
+      findOne?: boolean;
+      find?: boolean;
+      delete?: boolean;
+      count?: boolean;
+      insertOne?: boolean;
+      updateOne?: boolean;
+      deleteOne?: boolean;
+      subscription?: boolean;
+      subscriptionCount?: boolean;
+    }
+  | false;
 
 export type UIFieldConfigType =
   | false

--- a/packages/x/src/studio/models/Collection.ts
+++ b/packages/x/src/studio/models/Collection.ts
@@ -8,6 +8,7 @@ import {
   UIModeType,
   UICollectionConfigType,
   Resolvable,
+  CrudGenerator,
 } from "../defs";
 
 export type BehaviorsConfig = {
@@ -78,6 +79,21 @@ export class Collection extends BaseModel<Collection> {
   };
 
   /**
+   * Whether this collection will have crud queries and mutations, this crud will overforce the ui crud
+   */
+  crud: CrudGenerator = {
+    findOne: true,
+    find: true,
+    delete: true,
+    count: true,
+    insertOne: true,
+    updateOne: true,
+    deleteOne: true,
+    subscription: true,
+    subscriptionCount: true,
+  };
+
+  /**
    * Whether this collection is something users can see and we expose it as a Type
    */
   enableGraphQL:
@@ -130,6 +146,8 @@ export class Collection extends BaseModel<Collection> {
       f.app = this.app;
       f.clean();
     });
+    //override crud booleans on ui booleans
+    this.uniteCrudGenerators();
 
     this.cleanDuplicateFields();
     this.enableGraphQLCleaning();
@@ -243,6 +261,44 @@ export class Collection extends BaseModel<Collection> {
       return this.enableGraphQL;
     } else {
       return this.enableGraphQL[type];
+    }
+  }
+
+  //ovveride the crud ui to match the graphql crud
+  uniteCrudGenerators() {
+    if (!this.crud) {
+      this.ui = false;
+    }
+
+    if (this.ui && this.crud) {
+      const defaultCrud = {
+        findOne: true,
+        find: true,
+        delete: true,
+        count: true,
+        insertOne: true,
+        updateOne: true,
+        deleteOne: true,
+        subscription: true,
+        subscriptionCount: true,
+      };
+      //to work just on input crud variables that user enetered
+      this.crud = { ...defaultCrud, ...this.crud };
+      if (!this.crud.findOne) {
+        this.ui.view = false;
+      }
+      if (!this.crud.find || !this.crud.count) {
+        this.ui.list = false;
+      }
+      if (!this.crud.delete) {
+        this.ui.delete = false;
+      }
+      if (!this.crud.insertOne) {
+        this.ui.create = false;
+      }
+      if (!this.crud.updateOne) {
+        this.ui.edit = false;
+      }
     }
   }
 }

--- a/packages/x/templates/graphql/crudModule.graphql.ts.tpl
+++ b/packages/x/templates/graphql/crudModule.graphql.ts.tpl
@@ -1,25 +1,46 @@
 export default /* GraphQL */`
+
   type Query {
-    {{ crudName }}FindOne(query: QueryInput): {{ entityType }}
-    {{ crudName }}Find(query: QueryInput): [{{ entityType }}]!
-    {{ crudName }}Count(query: QueryInput): Int!
+     {{# if crudOperations.findOne }}
+      {{ crudName }}FindOne(query: QueryInput): {{ entityType }}
+     {{/ if }}
+     {{# if crudOperations.find }}
+      {{ crudName }}Find(query: QueryInput): [{{ entityType }}]!
+      {{/ if }}
+     {{# if crudOperations.count }}
+      {{ crudName }}Count(query: QueryInput): Int!
+      {{/ if }}
   }
 
   type Mutation {
     {{# if hasCustomInputs }}
-      {{ crudName }}InsertOne(document: {{ insertInputName }}Input!): {{ entityType }}
-      {{ crudName }}UpdateOne(_id: ObjectId!, document: {{ updateInputName }}Input!): {{ entityType }}!
+      {{# if crudOperations.insertOne }}
+        {{ crudName }}InsertOne(document: {{ insertInputName }}Input!): {{ entityType }}
+      {{/ if }}
+      {{# if crudOperations.updateOne }}
+        {{ crudName }}UpdateOne(_id: ObjectId!, document: {{ updateInputName }}Input!): {{ entityType }}!
+      {{/ if }}
     {{ else }}
-      {{ crudName }}InsertOne(document: EJSON!): {{ entityType }}
-      {{ crudName }}UpdateOne(_id: ObjectId!, modifier: EJSON!): {{ entityType }}!
+      {{# if crudOperations.insertOne }}
+        {{ crudName }}InsertOne(document: EJSON!): {{ entityType }}
+      {{/ if }}
+      {{# if crudOperations.updateOne }}
+        {{ crudName }}UpdateOne(_id: ObjectId!, modifier: EJSON!): {{ entityType }}!
+      {{/ if }}
     {{/ if }}
-    {{ crudName }}DeleteOne(_id: ObjectId!): Boolean
+    {{# if crudOperations.deleteOne }}
+      {{ crudName }}DeleteOne(_id: ObjectId!): Boolean
+    {{/ if }}
   }
 
   {{# if hasSubscriptions }}
     type Subscription {
-      {{ crudName }}Subscription(body: EJSON): SubscriptionEvent
-      {{ crudName }}SubscriptionCount(filters: EJSON): SubscriptionCountEvent
+       {{# if crudOperations.subscription }}
+        {{ crudName }}Subscription(body: EJSON): SubscriptionEvent
+      {{/ if }}
+       {{# if crudOperations.subscriptionCount }}
+        {{ crudName }}SubscriptionCount(filters: EJSON): SubscriptionCountEvent
+      {{/ if }}
     }
   {{/ if }}
 `

--- a/packages/x/templates/graphql/crudModule.resolvers.ts.tpl
+++ b/packages/x/templates/graphql/crudModule.resolvers.ts.tpl
@@ -4,7 +4,8 @@ import { IResolverMap } from "@bluelibs/graphql-bundle";
   {{ inputsImportLine }}
 {{/ if }}
 {{ collectionImportLine }}
-
+{{ crud }}
+{{ crudOperations.count }}
 export default {
   Query: [
     [
@@ -16,15 +17,21 @@ export default {
       {{/ if }}
     ], 
     {
+      {{# if crudOperations.findOne }}
       {{ crudName }}FindOne: [
       X.ToNovaOne({{ collectionClass }})
       ],
+      {{/ if }}
+      {{# if crudOperations.find }}
       {{ crudName }}Find: [
       X.ToNova({{ collectionClass }})
       ],
+      {{/ if }}
+      {{# if crudOperations.count }}
       {{ crudName }}Count: [
       X.ToCollectionCount({{ collectionClass }})
       ]
+      {{/ if }}
     }
   ],
   Mutation: [
@@ -37,12 +44,15 @@ export default {
     {{/ if }}
     ], {
       {{# if hasCustomInputs }}
+      {{# if crudOperations.insertOne }}
         {{ crudName }}InsertOne: [
           X.ToModel({{ insertInputName }}Input, { field: "document"}),
           X.Validate({ field: "document"}),
           X.ToDocumentInsert({{ collectionClass }}),
           X.ToNovaByResultID({{ collectionClass }})
         ],
+        {{/ if }}
+        {{# if crudOperations.updateOne }}
         {{ crudName }}UpdateOne: [
           X.ToModel({{ updateInputName }}Input, { field: "document"}),
           X.Validate({ field: "document"}),
@@ -54,37 +64,48 @@ export default {
           )),
           X.ToNovaByResultID({{ collectionClass }})
         ],
+        {{/ if }}
       {{ else }}
+      {{# if crudOperations.insertOne }}
         {{ crudName }}InsertOne: [
           X.ToDocumentInsert({{ collectionClass }}),
           X.ToNovaByResultID({{ collectionClass }})
         ],
+        {{/ if }}
+      {{# if crudOperations.updateOne }}
         {{ crudName }}UpdateOne: [
           X.CheckDocumentExists({{ collectionClass }}),
           X.ToDocumentUpdateByID({{ collectionClass }}),
           X.ToNovaByResultID({{ collectionClass }})
         ],
+        {{/ if }}
       {{/ if }}
+      {{# if crudOperations.deleteOne }}
       {{ crudName }}DeleteOne: [
         X.CheckDocumentExists({{ collectionClass }}),
         X.ToDocumentDeleteByID({{ collectionClass }})
       ]
+      {{/ if }}
     }
   ],
   {{# if hasSubscriptions }}
     Subscription: {
+      {{# if crudOperations.subscription }}
       {{ crudName }}Subscription: {
         resolve: (payload) => payload,
         subscribe: [
           X.ToSubscription({{ collectionClass }}),
         ]
       },
+      {{/ if }}
+    {{# if crudOperations.subscriptionCount }}
       {{ crudName }}SubscriptionCount: {
         resolve: (payload) => payload,
         subscribe: [
           X.ToSubscriptionCount({{ collectionClass }}),
         ]
       },
+      {{/ if }}
     },
   {{/ if }}
 } as IResolverMap;


### PR DESCRIPTION
Fix :
- the default value should not be an array
- with the last updates of the apollo client library, now the `[operation]` dynamic key is not needed anymore (we have started to get the bug after updating our admin dependencies)