### PR TITLE
(fix): prefix (un)subscribe with underscores

### DIFF
--- a/packages/smart/src/Smart.ts
+++ b/packages/smart/src/Smart.ts
@@ -75,7 +75,7 @@ export abstract class Smart<StateModel = any, Config = any> {
   /**
    * @param subscriber
    */
-  protected subscribe(subscriber: SmartSubscriber) {
+  protected __subscribe(subscriber: SmartSubscriber) {
     if (this.subscribers.indexOf(subscriber) === -1) {
       this.subscribers.push(subscriber);
     }
@@ -84,7 +84,7 @@ export abstract class Smart<StateModel = any, Config = any> {
   /**
    * @param subscriber
    */
-  protected unsubscribe(subscriber: SmartSubscriber) {
+  protected __unsubscribe(subscriber: SmartSubscriber) {
     this.subscribers = this.subscribers.filter((s) => s !== subscriber);
   }
 

--- a/packages/smart/src/hooks.ts
+++ b/packages/smart/src/hooks.ts
@@ -144,13 +144,13 @@ function reactToSmartStateChange(model) {
 
   useMemo(() => {
     // If we put this in useEffect it won't work initially as useEffect can be run async later
-    model.subscribe(forceUpdate);
+    model.__subscribe(forceUpdate);
     return null;
   }, []);
 
   useEffect(() => {
     return () => {
-      model.unsubscribe(forceUpdate);
+      model.__unsubscribe(forceUpdate);
     };
   }, []);
 }


### PR DESCRIPTION
The idea is that we don't inform people about the fact that Smarts have methods with the names of "subscribe" and "unsubscribe"; if you're not going to check for them, or if the IDE doesn't help you, you can end up overriding these functions and `useSmart` will not react to changes, hence you will be sad. (true story)

My solution was to prefix the methods with two underscores.