### PR TITLE
fix(service writer): do not import test files with extension ".ts"

### DIFF
--- a/packages/x/src/writers/ServiceWriter.ts
+++ b/packages/x/src/writers/ServiceWriter.ts
@@ -41,7 +41,7 @@ export class ServiceWriter extends BlueprintWriter {
     this.getWriter(UnitTestWriter).write(unitTestModel, session);
     fsOperator.sessionPrependFile(
       path.join(bundlePath, "__tests__", "index.ts"),
-      `import "./${model.serviceName}.service.test.ts";\n`
+      `import "./${model.serviceName}.service.test";\n`
     );
   }
 


### PR DESCRIPTION
Imagine wanting to run a test, using `npm run test`. In the index file of `__tests__`, it will try to import the `ts` file:

```
 FAIL  dist/__tests__/index.js
  ● Test suite failed to run

    Cannot find module './Business.service.test.ts' from 'dist/bundles/AppBundle/__tests__/index.js'

    Require stack:
      dist/bundles/AppBundle/__tests__/index.js
      dist/__tests__/index.js

      1 | import "./User.service.test";
    > 2 | import "./Business.service.test.ts";
        | ^
      3 | // import { container } from "../../../__tests__/ecosystem";
      4 |
      5 | test("dummy", () => {
```


Solution: remove the ".ts" extension from the import line