### PR TITLE
fix: use "^" instead of ">=" for react peer

### DIFF
--- a/packages/smart/package.json
+++ b/packages/smart/package.json
@@ -22,7 +22,7 @@
     "gen-doc": "typedoc ./src/index.ts --exclude ./src/__tests__ --out typeDocs --tsconfig tsconfig.json"
   },
   "peerDependencies": {
-    "react": ">=17.0.2"
+    "react": "^17.0.2"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^7.0.2",


### PR DESCRIPTION
The idea is that we encounter issues when we try to simply do `npm install` in `x-ui-react-router-bundle`, and the issue seems to come from `@bluelibs/smart` that allows `react` as peerDependency with `>=17.0.2`. This way, it tries to install `react@18.2.0` and it has conflicts with the rest of the packages. ...if I understood right.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @bluelibs/x-ui-react-router-bundle@1.0.4
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   peer react@">=17.0.2" from @bluelibs/smart@1.0.1
npm ERR!   node_modules/@bluelibs/smart
npm ERR!     peer @bluelibs/smart@"^1.0.0" from @bluelibs/x-ui-guardian-bundle@1.3.1
npm ERR!     node_modules/@bluelibs/x-ui-guardian-bundle
npm ERR!       peer @bluelibs/x-ui-guardian-bundle@"^1.0.0" from the root project
npm ERR!   peerOptional react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @apollo/client@3.7.4
npm ERR!   node_modules/@apollo/client
npm ERR!     peer @apollo/client@"^3.4.16" from @bluelibs/ui-apollo-bundle@1.0.2
npm ERR!     node_modules/@bluelibs/ui-apollo-bundle
npm ERR!       peer @bluelibs/ui-apollo-bundle@"^1.0.0" from @bluelibs/x-ui-guardian-bundle@1.3.1
npm ERR!       node_modules/@bluelibs/x-ui-guardian-bundle
npm ERR!         peer @bluelibs/x-ui-guardian-bundle@"^1.0.0" from the root project
npm ERR!     peer @apollo/client@"^3.0.0" from apollo-upload-client@16.0.0
npm ERR!     node_modules/apollo-upload-client
npm ERR!       peer apollo-upload-client@"^16.0.0" from @bluelibs/ui-apollo-bundle@1.0.2
npm ERR!       node_modules/@bluelibs/ui-apollo-bundle
npm ERR!         peer @bluelibs/ui-apollo-bundle@"^1.0.0" from @bluelibs/x-ui-guardian-bundle@1.3.1
npm ERR!         node_modules/@bluelibs/x-ui-guardian-bundle
npm ERR!   1 more (react-dom)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^17.0.2" from @bluelibs/ui-apollo-bundle@1.0.2
npm ERR! node_modules/@bluelibs/ui-apollo-bundle
npm ERR!   peer @bluelibs/ui-apollo-bundle@"^1.0.0" from @bluelibs/x-ui-guardian-bundle@1.3.1
npm ERR!   node_modules/@bluelibs/x-ui-guardian-bundle
npm ERR!     peer @bluelibs/x-ui-guardian-bundle@"^1.0.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/qfl1ck32/.npm/eresolve-report.txt for a full report.
```