### PR TITLE
[R] (nova) Add foreignField when defining relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ packages/dp-*
 packages/graphql-final
 packages/x-cell-bundle
 packages/apollo-lambda-bundle
+.env

--- a/packages/nova/DOCUMENTATION.md
+++ b/packages/nova/DOCUMENTATION.md
@@ -259,6 +259,22 @@ addLinks(Users, {
 });
 ```
 
+### Foreign keys
+
+By default, Nova uses the field `_id` of the collection B as the foreign field. Sometimes you may want another field to be your foreign key.
+
+You can decide which foreign field to use by specifying `foreignField` in the relationship configuration.
+
+```typescript
+addLinks(Users, {
+  // Don't use the `Comment._id` field as a foreign field for the lookup but `Comment.anotherField`
+  comments: {
+    collection: () => Comment,
+    foreignField: 'anotherField'
+  },
+});
+```
+
 ### Aliasing
 
 Sometimes you may find useful to fetch the same link but in different contexts, for example you want to get a Company with the last 3 invoices and with overdue invoices without much hassle (see the next section for more information on `query()` and the `$` field):
@@ -806,6 +822,8 @@ However, we currently can't work with fields in arrays of objects, or have array
   ]
 }
 ```
+
+This limitation also applies to the `foreignField` option.
 
 ## Hypernova
 

--- a/packages/nova/src/__tests__/connection.ts
+++ b/packages/nova/src/__tests__/connection.ts
@@ -1,7 +1,7 @@
 import * as mongodb from "mongodb";
 
 export const client = new mongodb.MongoClient(
-  "mongodb://localhost:27017/test",
+  process.env.TEST_DB ?? "mongodb://localhost:27017/test",
   {
     // useUnifiedTopology: true,
   }

--- a/packages/nova/src/core/defs.ts
+++ b/packages/nova/src/core/defs.ts
@@ -58,6 +58,7 @@ export type HardwiredFiltersOptions = {
 export interface ILinkCollectionOptions {
   collection: () => Collection;
   field?: string;
+  foreignField?: string;
   unique?: boolean;
   many?: boolean;
   /**

--- a/packages/nova/src/core/query/hypernova/processDirectNode.ts
+++ b/packages/nova/src/core/query/hypernova/processDirectNode.ts
@@ -22,9 +22,16 @@ export default function processDirectNode(childCollectionNode: CollectionNode) {
     return;
   }
 
-  const resultsByKeyId = _.groupBy(childCollectionNode.results, (r) =>
-    r[linkForeignStorageField].toString()
-  );
+  const resultsByKeyId = _.groupBy(childCollectionNode.results, (r) => {
+    const linkForeignStorageFieldDot =
+      linkForeignStorageField.indexOf(".") >= 0;
+
+    const value = linkForeignStorageFieldDot
+      ? _.get(r, linkForeignStorageField)
+      : r[linkForeignStorageField];
+
+    return value.toString();
+  });
 
   if (linker.strategy === LinkStrategy.ONE) {
     parent.results.forEach((parentResult) => {

--- a/packages/nova/src/core/query/hypernova/processDirectNode.ts
+++ b/packages/nova/src/core/query/hypernova/processDirectNode.ts
@@ -11,6 +11,7 @@ export default function processDirectNode(childCollectionNode: CollectionNode) {
   const linker = childCollectionNode.linker;
 
   const linkStorageField = linker.linkStorageField;
+  const linkForeignStorageField = linker.linkForeignStorageField;
 
   if (childCollectionNode.results.length === 0) {
     const defaultValue = linker.strategy === LinkStrategy.ONE ? null : [];
@@ -22,7 +23,7 @@ export default function processDirectNode(childCollectionNode: CollectionNode) {
   }
 
   const resultsByKeyId = _.groupBy(childCollectionNode.results, (r) =>
-    r._id.toString()
+    r[linkForeignStorageField].toString()
   );
 
   if (linker.strategy === LinkStrategy.ONE) {
@@ -48,10 +49,10 @@ export default function processDirectNode(childCollectionNode: CollectionNode) {
 
       const data = [];
 
-      value.forEach((_id) => {
-        const result = resultsByKeyId[_id];
+      value.forEach((foreignKey) => {
+        const result = resultsByKeyId[foreignKey];
         if (result) {
-          data.push(_.first(resultsByKeyId[_id]));
+          data.push(_.first(resultsByKeyId[foreignKey]));
         }
       });
 

--- a/packages/nova/src/core/query/hypernova/processRecursiveNode.ts
+++ b/packages/nova/src/core/query/hypernova/processRecursiveNode.ts
@@ -13,6 +13,7 @@ export default async function processRecursiveNode(
   const parentResults = childCollectionNode.parent.results;
   const allResults = [];
   const linkStorageField = childCollectionNode.linkStorageField;
+  const linkForeignStorageField = childCollectionNode.linkForeignStorageField;
   const linkName = childCollectionNode.name;
   const isMany = childCollectionNode.linker.isMany();
 
@@ -22,7 +23,7 @@ export default async function processRecursiveNode(
     for (const parentResult of parentResults) {
       const results = await childCollectionNode.toArray(
         {
-          [linkStorageField]: { $in: [parentResult._id] }
+          [linkStorageField]: { $in: [parentResult[linkForeignStorageField]] },
         },
         parentResult
       );
@@ -43,7 +44,7 @@ export default async function processRecursiveNode(
 
       const results = await childCollectionNode.toArray(
         {
-          _id: { $in }
+          [linkForeignStorageField]: { $in },
         },
         parentResult
       );
@@ -53,5 +54,5 @@ export default async function processRecursiveNode(
     }
   }
 
-  childCollectionNode.results = _.uniqBy(allResults, id => id.toString());
+  childCollectionNode.results = _.uniqBy(allResults, (id) => id.toString());
 }

--- a/packages/nova/src/core/query/hypernova/processVirtualNode.ts
+++ b/packages/nova/src/core/query/hypernova/processVirtualNode.ts
@@ -13,7 +13,8 @@ export default function processVirtualNode(
   childCollectionNode: CollectionNode
 ) {
   const parentResults = childCollectionNode.parent.results;
-  const linkStorageField = childCollectionNode.linkStorageField;
+  const linkStorageField = childCollectionNode.linkForeignStorageField;
+  const linkForeignStorageField = childCollectionNode.linkForeignStorageField;
   const linkName = childCollectionNode.name;
   const isMany = childCollectionNode.linker.isMany();
   const linkStorageFieldDot = linkStorageField.indexOf(".") >= 0;
@@ -28,7 +29,9 @@ export default function processVirtualNode(
         (childResult) => {
           const linkingStorage = getStorageValue(childResult);
           if (linkingStorage) {
-            return linkingStorage.find((l) => idsEqual(l, parentResult._id));
+            return linkingStorage.find((l) =>
+              idsEqual(l, parentResult[linkForeignStorageField])
+            );
           }
         }
       );
@@ -36,7 +39,8 @@ export default function processVirtualNode(
   } else {
     const group = _.groupBy(childCollectionNode.results, linkStorageField);
     parentResults.forEach((parentResult) => {
-      parentResult[linkName] = group[parentResult._id.toString()] || [];
+      parentResult[linkName] =
+        group[parentResult[linkForeignStorageField].toString()] || [];
     });
   }
 }

--- a/packages/nova/src/core/query/hypernova/processVirtualNode.ts
+++ b/packages/nova/src/core/query/hypernova/processVirtualNode.ts
@@ -13,25 +13,31 @@ export default function processVirtualNode(
   childCollectionNode: CollectionNode
 ) {
   const parentResults = childCollectionNode.parent.results;
-  const linkStorageField = childCollectionNode.linkForeignStorageField;
+  const linkStorageField = childCollectionNode.linkStorageField;
   const linkForeignStorageField = childCollectionNode.linkForeignStorageField;
   const linkName = childCollectionNode.name;
   const isMany = childCollectionNode.linker.isMany();
   const linkStorageFieldDot = linkStorageField.indexOf(".") >= 0;
+  const linkForeignStorageFieldDot = linkForeignStorageField.indexOf(".") >= 0;
 
   const getStorageValue = linkStorageFieldDot
     ? (childResult) => _.get(childResult, linkStorageField)
     : (childResult) => childResult[linkStorageField];
 
+  const getForeignStorageValue = linkForeignStorageFieldDot
+    ? (parentResult) => _.get(parentResult, linkForeignStorageField)
+    : (parentResult) => parentResult[linkForeignStorageField];
+
   if (isMany) {
     parentResults.forEach((parentResult) => {
+      const foreignStorage = getForeignStorageValue(parentResult);
+
       parentResult[linkName] = childCollectionNode.results.filter(
         (childResult) => {
           const linkingStorage = getStorageValue(childResult);
-          if (linkingStorage) {
-            return linkingStorage.find((l) =>
-              idsEqual(l, parentResult[linkForeignStorageField])
-            );
+
+          if (linkingStorage && foreignStorage) {
+            return linkingStorage.find((l) => idsEqual(l, foreignStorage));
           }
         }
       );
@@ -40,7 +46,7 @@ export default function processVirtualNode(
     const group = _.groupBy(childCollectionNode.results, linkStorageField);
     parentResults.forEach((parentResult) => {
       parentResult[linkName] =
-        group[parentResult[linkForeignStorageField].toString()] || [];
+        group[getForeignStorageValue(parentResult).toString()] || [];
     });
   }
 }

--- a/packages/nova/src/core/query/lib/createFilters.ts
+++ b/packages/nova/src/core/query/lib/createFilters.ts
@@ -10,20 +10,37 @@ export function createFilters(childCollectionNode: CollectionNode) {
   const linker = childCollectionNode.linker;
   const isVirtual = linker.isVirtual();
   const linkStorageField = linker.linkStorageField;
+  const linkForeignStorageField = linker.linkForeignStorageField;
   const parentResults = childCollectionNode.parent.results;
   const isMany = childCollectionNode.linker.isMany();
 
   if (isVirtual) {
     if (isMany) {
-      return createManyVirtual(parentResults, linkStorageField);
+      return createManyVirtual(
+        parentResults,
+        linkStorageField,
+        linkForeignStorageField
+      );
     } else {
-      return createOneVirtual(parentResults, linkStorageField);
+      return createOneVirtual(
+        parentResults,
+        linkStorageField,
+        linkForeignStorageField
+      );
     }
   } else {
     if (isMany) {
-      return createManyDirect(parentResults, linkStorageField);
+      return createManyDirect(
+        parentResults,
+        linkStorageField,
+        linkForeignStorageField
+      );
     } else {
-      return createOneDirect(parentResults, linkStorageField);
+      return createOneDirect(
+        parentResults,
+        linkStorageField,
+        linkForeignStorageField
+      );
     }
   }
 }
@@ -32,9 +49,13 @@ function uniqIdsComparator(id) {
   return id ? id.toString() : null;
 }
 
-function createOneDirect(parentResults: any[], linkStorageField: string) {
+function createOneDirect(
+  parentResults: any[],
+  linkStorageField: string,
+  linkForeignStorageField: string
+) {
   return {
-    _id: {
+    [linkForeignStorageField]: {
       $in: _.uniqBy(
         _.map(parentResults, (e) => {
           return _.get(e, linkStorageField);
@@ -45,28 +66,43 @@ function createOneDirect(parentResults: any[], linkStorageField: string) {
   };
 }
 
-function createOneVirtual(parentResults: any[], linkStorageField: string) {
+function createOneVirtual(
+  parentResults: any[],
+  linkStorageField: string,
+  linkForeignStorageField: string
+) {
   return {
     [linkStorageField]: {
-      $in: _.uniqBy(_.map(parentResults, "_id"), uniqIdsComparator),
+      $in: _.uniqBy(
+        _.map(parentResults, linkForeignStorageField),
+        uniqIdsComparator
+      ),
     },
   };
 }
 
-function createManyDirect(parentResults: any[], linkStorageField: string) {
+function createManyDirect(
+  parentResults: any[],
+  linkStorageField: string,
+  linkForeignStorageField: string
+) {
   const arrayOfIds: any[] = _.flatten(
     _.map(parentResults, (e) => _.get(e, linkStorageField))
   ).filter((e) => e !== undefined);
 
   return {
-    _id: {
+    [linkForeignStorageField]: {
       $in: _.uniqBy(arrayOfIds, uniqIdsComparator),
     },
   };
 }
 
-function createManyVirtual(parentResults: any[], linkStorageField: string) {
-  const arrayOfIds = _.flatten(_.map(parentResults, "_id"));
+function createManyVirtual(
+  parentResults: any[],
+  linkStorageField: string,
+  linkForeignStorageField: string
+) {
+  const arrayOfIds = _.flatten(_.map(parentResults, linkForeignStorageField));
   return {
     [linkStorageField]: {
       $in: _.uniqBy(arrayOfIds, uniqIdsComparator),

--- a/packages/nova/src/core/query/nodes/CollectionNode.ts
+++ b/packages/nova/src/core/query/nodes/CollectionNode.ts
@@ -95,6 +95,7 @@ export default class CollectionNode implements INode {
    */
   public linker: Linker;
   public linkStorageField: string;
+  public linkForeignStorageField: string;
   public readonly context: IQueryContext;
   public results: any = [];
 
@@ -163,10 +164,17 @@ export default class CollectionNode implements INode {
     this.isVirtual = linker.isVirtual();
     this.isOneResult = linker.isOneResult();
     this.linkStorageField = linker.linkStorageField;
+    this.linkForeignStorageField = linker.linkForeignStorageField;
     if (this.isVirtual) {
       this.addField(this.linkStorageField, {}, true);
+      if (this.linkForeignStorageField !== "_id") {
+        parent.addField(this.linkForeignStorageField, {}, true);
+      }
     } else {
       parent.addField(this.linkStorageField, {}, true);
+      if (this.linkForeignStorageField !== "_id") {
+        this.addField(this.linkForeignStorageField, {}, true);
+      }
     }
   }
 

--- a/packages/nova/src/core/quickLinkers.ts
+++ b/packages/nova/src/core/quickLinkers.ts
@@ -9,6 +9,10 @@ export interface IQuickLinkingArguments {
    * Defaults to linkName + 'Id' or 'Ids' depending how many we store
    */
   field?: string;
+  /**
+   * @default _id
+   */
+  foreignField?: string;
 }
 
 export function oneToOne(
@@ -20,6 +24,7 @@ export function oneToOne(
     [options.linkName]: {
       collection: () => C2,
       field: options.field || `${options.linkName}Id`,
+      foreignField: options.foreignField,
       unique: true,
     },
   });
@@ -41,6 +46,7 @@ export function manyToOne(
     [options.linkName]: {
       collection: () => C2,
       field: options.field || `${options.linkName}Id`,
+      foreignField: options.foreignField,
     },
   });
 
@@ -61,6 +67,7 @@ export function oneToMany(
     [options.linkName]: {
       collection: () => C2,
       field: options.field || `${options.linkName}Ids`,
+      foreignField: options.foreignField,
       many: true,
       unique: true,
     },
@@ -83,6 +90,7 @@ export function manyToMany(
     [options.linkName]: {
       collection: () => C2,
       field: options.field || `${options.linkName}Ids`,
+      foreignField: options.foreignField,
       many: true,
     },
   });


### PR DESCRIPTION
In the LinkCollectionOptions, I added a new property named `foreignField` aside from the `field` property. 

It allows customization of the foreign field of a nova relation instead of the hardcoded `_id` foreign field