### PR TITLE
Replace subscriptions-transport-ws with graphql-ws

### DIFF
--- a/packages/apollo-bundle/src/declarations.ts
+++ b/packages/apollo-bundle/src/declarations.ts
@@ -1,13 +1,13 @@
-import "@bluelibs/graphql-bundle";
 import { ContainerInstance } from "@bluelibs/core";
+import "@bluelibs/graphql-bundle";
 import * as express from "express";
-import { ExecutionParams } from "subscriptions-transport-ws";
+import { Context } from "graphql-ws";
 
 declare module "@bluelibs/graphql-bundle" {
   export interface IGraphQLContext {
     container: ContainerInstance;
     req: express.Request;
     res: express.Response;
-    connection?: ExecutionParams;
+    connection?: Context;
   }
 }

--- a/packages/apollo-bundle/src/defs.ts
+++ b/packages/apollo-bundle/src/defs.ts
@@ -1,9 +1,9 @@
-import * as express from "express";
-import { ExecutionParams } from "subscriptions-transport-ws";
-import { ContainerInstance } from "@bluelibs/core";
-import { UploadOptions } from "graphql-upload/GraphQLUpload.mjs";
-import { RequestHandler } from "express";
 import { ApolloServerOptions } from "@apollo/server";
+import { ContainerInstance } from "@bluelibs/core";
+import * as express from "express";
+import { RequestHandler } from "express";
+import { UploadOptions } from "graphql-upload/GraphQLUpload.mjs";
+import { Context } from "graphql-ws";
 
 export type ApolloBundleConfigType = {
   port?: number;
@@ -36,7 +36,7 @@ export interface IRouteType {
 export interface IGraphQLContext {
   req: express.Request;
   res: express.Response;
-  connection?: ExecutionParams;
+  connection?: Context;
   container: ContainerInstance;
   /**
    * Connection Parameters from Websocket

--- a/packages/ui-apollo-bundle/package.json
+++ b/packages/ui-apollo-bundle/package.json
@@ -44,7 +44,6 @@
     "apollo-link-context": "^1.0.20",
     "jest": "^27.3.1",
     "react": "^17.0.0 || ^18.0.0",
-    "subscriptions-transport-ws": "^0.9.19",
     "ts-jest": "^27.0.7",
     "typescript": "^4.9.5"
   }

--- a/packages/ui-apollo-bundle/src/events/index.ts
+++ b/packages/ui-apollo-bundle/src/events/index.ts
@@ -1,6 +1,5 @@
 import { GraphQLRequest } from "@apollo/client/link/core";
 import { Event } from "@bluelibs/core";
-import { ConnectionParams } from "subscriptions-transport-ws";
 
 export class ApolloBeforeOperationEvent extends Event<{
   context: {
@@ -10,5 +9,5 @@ export class ApolloBeforeOperationEvent extends Event<{
 }> {}
 
 export class ApolloSubscriptionOnConnectionParamsSetEvent extends Event<{
-  params: ConnectionParams;
+  params: Record<string, any>;
 }> {}

--- a/packages/ui-apollo-bundle/src/graphql/ApolloClient.ts
+++ b/packages/ui-apollo-bundle/src/graphql/ApolloClient.ts
@@ -1,13 +1,12 @@
 import { ApolloClient as BaseApolloClient } from "@apollo/client/core";
-import { EventManager, Service } from "@bluelibs/core";
-import { ContainerInstance } from "@bluelibs/core";
-import { SubscriptionClient } from "subscriptions-transport-ws";
+import { ContainerInstance, EventManager, Service } from "@bluelibs/core";
+import { Client } from "graphql-ws";
 import { IUIApolloBundleConfig } from "../defs";
 import { createApolloLink } from "./utils/createApolloLink";
 
 @Service()
 export class ApolloClient extends BaseApolloClient<any> {
-  public subscriptionClient?: SubscriptionClient;
+  public subscriptionClient?: Client;
 
   constructor(container: ContainerInstance, options: IUIApolloBundleConfig) {
     const { finalLink, subscriptionClient } = createApolloLink(

--- a/packages/x/templates/microservice/frontend-next/package.json
+++ b/packages/x/templates/microservice/frontend-next/package.json
@@ -35,7 +35,7 @@
     "query-string": "^7.0.1",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
-    "subscriptions-transport-ws": "^0.9.19"
+    "graphql-ws": "^5.11.3"
   },
   "devDependencies": {
     "@types/node": "16.11.6",


### PR DESCRIPTION
In the new version `@bluelibs/apollo-bundle@2.X` switched from `subscriptions-transport-ws` to `graphql-ws` to handle Subscriptions.

But the new implementation does not seems complete. The client (`@bluelibs/ui-apollo-bundle`) still uses the older `subscriptions-transport-ws`. And on the server the GraphQL context is not properly initialized for Subscription resolvers.

I tried patching the package on my side, and came to do these modifications in order to have a fonctionning websocket server for GraphQL Subscriptions.

I open a Pull Request here in order to share the modifications, if my problem is found to be a real bug on bluelibs, fell free to  consider this for merging.
Else if I was the only having this error, I will close this PR and try to find where in my installation the problem is.