### PR TITLE
Prevent infinite loop when wrapping findOneAndUpdate

### DIFF
--- a/packages/mongo-bundle/src/behaviors/validate.ts
+++ b/packages/mongo-bundle/src/behaviors/validate.ts
@@ -216,7 +216,7 @@ export default function validate(behaviorOptions: IValidateBehaviorOptions) {
         }
 
         // Test if the update worked and is consistent
-        const document = collection.findOne({ _id: element.value._id });
+        const document = await collection.findOne({ _id: element.value._id });
         await validatorService.validate(document, {
           ...behaviorOptions.options,
           model: behaviorOptions.model,

--- a/packages/mongo-bundle/src/behaviors/validate.ts
+++ b/packages/mongo-bundle/src/behaviors/validate.ts
@@ -204,7 +204,7 @@ export default function validate(behaviorOptions: IValidateBehaviorOptions) {
             options,
           })
         );
-        const element = await collection.findOneAndUpdate(
+        const element = await collection.collection.findOneAndUpdate(
           filter,
           update,
           options


### PR DESCRIPTION
When using the validator bundle, it seems like this caused an infinite loop, since the wrapped findOneAndUpdate call called itself over and over again.

With these 2 changes I still get the following error:

```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
MongoTransactionError: Cannot call abortTransaction twice
    at ClientSession.abortTransaction (/Users/flo/dev/ogment-2/backend/node_modules/mongodb/src/sessions.ts:613:13)
    at ClientSession.withTransaction (/Users/flo/dev/ogment-2/backend/node_modules/mongodb/src/sessions.ts:794:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async DatabaseService.transact (.../node_modules/@bluelibs/mongo-bundle/src/services/DatabaseService.ts:122:7)
```

Any idea what is wrong here?