### PR TITLE
Make sure findOneAndUpdate returns its result

### DIFF
--- a/packages/mongo-bundle/src/behaviors/validate.ts
+++ b/packages/mongo-bundle/src/behaviors/validate.ts
@@ -204,19 +204,20 @@ export default function validate(behaviorOptions: IValidateBehaviorOptions) {
             options,
           })
         );
-        const element = await collection.collection.findOneAndUpdate(
+
+        result = await collection.collection.findOneAndUpdate(
           filter,
           update,
           options
         );
 
-        if (!element.value) {
-          // No element was found
+        if (!result.value) {
+          // No document was found
           return;
         }
 
         // Test if the update worked and is consistent
-        const document = await collection.findOne({ _id: element.value._id });
+        const document = await collection.findOne({ _id: result.value._id });
         await validatorService.validate(document, {
           ...behaviorOptions.options,
           model: behaviorOptions.model,


### PR DESCRIPTION
Things seem to be working better on my side since 1.8.3, so I stumbled on another small issue with findOneAndUpdate. Would be nice to add a few tests maybe, I don't think findOneAndUpdate was working before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved document validation and update logic in MongoDB operations
	- Enhanced handling of `findOneAndUpdate` method to ensure consistent result processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->